### PR TITLE
Add none option

### DIFF
--- a/px-number-formatter-api.json
+++ b/px-number-formatter-api.json
@@ -9,16 +9,16 @@
         {
           "name": "format",
           "type": "string",
-          "description": "The format used to generate the output",
+          "description": "The format used to generate the output. Set to a [valid numbro.js\nformat string](http://numbrojs.com/format.html).\n\nSet to \"NONE\" to skip formatting and use the `value` to set the\n`formattedValue` directly.",
           "privacy": "public",
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 38,
+              "line": 42,
               "column": 6
             },
             "end": {
-              "line": 40,
+              "line": 44,
               "column": 7
             }
           },
@@ -35,11 +35,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 6
             },
             "end": {
-              "line": 48,
+              "line": 52,
               "column": 7
             }
           },
@@ -57,11 +57,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 53,
+              "line": 57,
               "column": 6
             },
             "end": {
-              "line": 56,
+              "line": 60,
               "column": 7
             }
           },
@@ -79,11 +79,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 61,
+              "line": 65,
               "column": 6
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 7
             }
           },
@@ -100,11 +100,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 81,
+              "line": 85,
               "column": 8
             },
             "end": {
-              "line": 83,
+              "line": 87,
               "column": 9
             }
           },
@@ -121,11 +121,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 89,
+              "line": 93,
               "column": 8
             },
             "end": {
-              "line": 92,
+              "line": 96,
               "column": 9
             }
           },
@@ -144,11 +144,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 97,
+              "line": 101,
               "column": 8
             },
             "end": {
-              "line": 101,
+              "line": 105,
               "column": 9
             }
           },
@@ -167,11 +167,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 106,
+              "line": 110,
               "column": 8
             },
             "end": {
-              "line": 109,
+              "line": 113,
               "column": 9
             }
           },
@@ -190,11 +190,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 114,
+              "line": 118,
               "column": 8
             },
             "end": {
-              "line": 117,
+              "line": 121,
               "column": 9
             }
           },
@@ -213,11 +213,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 122,
+              "line": 126,
               "column": 8
             },
             "end": {
-              "line": 125,
+              "line": 129,
               "column": 9
             }
           },
@@ -236,11 +236,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 130,
+              "line": 134,
               "column": 8
             },
             "end": {
-              "line": 133,
+              "line": 137,
               "column": 9
             }
           },
@@ -259,11 +259,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 138,
+              "line": 142,
               "column": 8
             },
             "end": {
-              "line": 140,
+              "line": 144,
               "column": 9
             }
           },
@@ -281,11 +281,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 149,
+              "line": 153,
               "column": 6
             },
             "end": {
-              "line": 152,
+              "line": 156,
               "column": 7
             }
           },
@@ -300,11 +300,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 157,
+              "line": 161,
               "column": 6
             },
             "end": {
-              "line": 181,
+              "line": 176,
               "column": 7
             }
           },
@@ -317,17 +317,49 @@
           "inheritedFrom": "PxNumberFormatter.formatter"
         },
         {
+          "name": "_getFormattedValue",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "px-number-formatter-behavior.html",
+            "start": {
+              "line": 183,
+              "column": 6
+            },
+            "end": {
+              "line": 191,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "string"
+            },
+            {
+              "name": "format",
+              "type": "?string"
+            },
+            {
+              "name": "currency",
+              "type": "boolean"
+            }
+          ],
+          "inheritedFrom": "PxNumberFormatter.formatter"
+        },
+        {
           "name": "_unformat",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 186,
+              "line": 196,
               "column": 6
             },
             "end": {
-              "line": 190,
+              "line": 200,
               "column": 7
             }
           },
@@ -346,11 +378,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 195,
+              "line": 205,
               "column": 6
             },
             "end": {
-              "line": 200,
+              "line": 210,
               "column": 7
             }
           },
@@ -369,11 +401,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 205,
+              "line": 215,
               "column": 6
             },
             "end": {
-              "line": 208,
+              "line": 218,
               "column": 7
             }
           },
@@ -392,11 +424,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 213,
+              "line": 223,
               "column": 6
             },
             "end": {
-              "line": 216,
+              "line": 226,
               "column": 7
             }
           },
@@ -415,11 +447,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 221,
+              "line": 231,
               "column": 6
             },
             "end": {
-              "line": 226,
+              "line": 236,
               "column": 7
             }
           },
@@ -437,11 +469,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 38,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 43,
               "column": 5
             }
           },
@@ -459,11 +491,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 31,
+          "line": 29,
           "column": 10
         },
         "end": {
-          "line": 47,
+          "line": 45,
           "column": 3
         }
       },
@@ -472,15 +504,15 @@
       "attributes": [
         {
           "name": "format",
-          "description": "The format used to generate the output",
+          "description": "The format used to generate the output. Set to a [valid numbro.js\nformat string](http://numbrojs.com/format.html).\n\nSet to \"NONE\" to skip formatting and use the `value` to set the\n`formattedValue` directly.",
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 38,
+              "line": 42,
               "column": 6
             },
             "end": {
-              "line": 40,
+              "line": 44,
               "column": 7
             }
           },
@@ -494,11 +526,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 6
             },
             "end": {
-              "line": 48,
+              "line": 52,
               "column": 7
             }
           },
@@ -512,11 +544,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 53,
+              "line": 57,
               "column": 6
             },
             "end": {
-              "line": 56,
+              "line": 60,
               "column": 7
             }
           },
@@ -530,11 +562,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 61,
+              "line": 65,
               "column": 6
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 7
             }
           },
@@ -548,11 +580,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 81,
+              "line": 85,
               "column": 8
             },
             "end": {
-              "line": 83,
+              "line": 87,
               "column": 9
             }
           },
@@ -566,11 +598,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 89,
+              "line": 93,
               "column": 8
             },
             "end": {
-              "line": 92,
+              "line": 96,
               "column": 9
             }
           },
@@ -584,11 +616,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 97,
+              "line": 101,
               "column": 8
             },
             "end": {
-              "line": 101,
+              "line": 105,
               "column": 9
             }
           },
@@ -602,11 +634,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 106,
+              "line": 110,
               "column": 8
             },
             "end": {
-              "line": 109,
+              "line": 113,
               "column": 9
             }
           },
@@ -620,11 +652,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 114,
+              "line": 118,
               "column": 8
             },
             "end": {
-              "line": 117,
+              "line": 121,
               "column": 9
             }
           },
@@ -638,11 +670,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 122,
+              "line": 126,
               "column": 8
             },
             "end": {
-              "line": 125,
+              "line": 129,
               "column": 9
             }
           },
@@ -656,11 +688,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 130,
+              "line": 134,
               "column": 8
             },
             "end": {
-              "line": 133,
+              "line": 137,
               "column": 9
             }
           },
@@ -674,11 +706,11 @@
           "sourceRange": {
             "file": "px-number-formatter-behavior.html",
             "start": {
-              "line": 138,
+              "line": 142,
               "column": 8
             },
             "end": {
-              "line": 140,
+              "line": 144,
               "column": 9
             }
           },
@@ -722,15 +754,15 @@
             {
               "name": "format",
               "type": "string",
-              "description": "The format used to generate the output",
+              "description": "The format used to generate the output. Set to a [valid numbro.js\nformat string](http://numbrojs.com/format.html).\n\nSet to \"NONE\" to skip formatting and use the `value` to set the\n`formattedValue` directly.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 38,
+                  "line": 42,
                   "column": 6
                 },
                 "end": {
-                  "line": 40,
+                  "line": 44,
                   "column": 7
                 }
               },
@@ -745,11 +777,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 45,
+                  "line": 49,
                   "column": 6
                 },
                 "end": {
-                  "line": 48,
+                  "line": 52,
                   "column": 7
                 }
               },
@@ -765,11 +797,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 53,
+                  "line": 57,
                   "column": 6
                 },
                 "end": {
-                  "line": 56,
+                  "line": 60,
                   "column": 7
                 }
               },
@@ -785,11 +817,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 61,
+                  "line": 65,
                   "column": 6
                 },
                 "end": {
-                  "line": 63,
+                  "line": 67,
                   "column": 7
                 }
               },
@@ -808,7 +840,7 @@
               "column": 2
             },
             "end": {
-              "line": 65,
+              "line": 69,
               "column": 4
             }
           },
@@ -817,14 +849,14 @@
           "attributes": [
             {
               "name": "format",
-              "description": "The format used to generate the output",
+              "description": "The format used to generate the output. Set to a [valid numbro.js\nformat string](http://numbrojs.com/format.html).\n\nSet to \"NONE\" to skip formatting and use the `value` to set the\n`formattedValue` directly.",
               "sourceRange": {
                 "start": {
-                  "line": 38,
+                  "line": 42,
                   "column": 6
                 },
                 "end": {
-                  "line": 40,
+                  "line": 44,
                   "column": 7
                 }
               },
@@ -836,11 +868,11 @@
               "description": "Specify whether the value should be formatted as a currency",
               "sourceRange": {
                 "start": {
-                  "line": 45,
+                  "line": 49,
                   "column": 6
                 },
                 "end": {
-                  "line": 48,
+                  "line": 52,
                   "column": 7
                 }
               },
@@ -852,11 +884,11 @@
               "description": "Provide localization for currency formatting",
               "sourceRange": {
                 "start": {
-                  "line": 53,
+                  "line": 57,
                   "column": 6
                 },
                 "end": {
-                  "line": 56,
+                  "line": 60,
                   "column": 7
                 }
               },
@@ -868,11 +900,11 @@
               "description": "Provide a new default format for `0` value",
               "sourceRange": {
                 "start": {
-                  "line": 61,
+                  "line": 65,
                   "column": 6
                 },
                 "end": {
-                  "line": 63,
+                  "line": 67,
                   "column": 7
                 }
               },
@@ -895,15 +927,15 @@
             {
               "name": "format",
               "type": "string",
-              "description": "The format used to generate the output",
+              "description": "The format used to generate the output. Set to a [valid numbro.js\nformat string](http://numbrojs.com/format.html).\n\nSet to \"NONE\" to skip formatting and use the `value` to set the\n`formattedValue` directly.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 38,
+                  "line": 42,
                   "column": 6
                 },
                 "end": {
-                  "line": 40,
+                  "line": 44,
                   "column": 7
                 }
               },
@@ -919,11 +951,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 45,
+                  "line": 49,
                   "column": 6
                 },
                 "end": {
-                  "line": 48,
+                  "line": 52,
                   "column": 7
                 }
               },
@@ -940,11 +972,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 53,
+                  "line": 57,
                   "column": 6
                 },
                 "end": {
-                  "line": 56,
+                  "line": 60,
                   "column": 7
                 }
               },
@@ -961,11 +993,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 61,
+                  "line": 65,
                   "column": 6
                 },
                 "end": {
-                  "line": 63,
+                  "line": 67,
                   "column": 7
                 }
               },
@@ -981,11 +1013,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 81,
+                  "line": 85,
                   "column": 8
                 },
                 "end": {
-                  "line": 83,
+                  "line": 87,
                   "column": 9
                 }
               },
@@ -1000,11 +1032,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 89,
+                  "line": 93,
                   "column": 8
                 },
                 "end": {
-                  "line": 92,
+                  "line": 96,
                   "column": 9
                 }
               },
@@ -1021,11 +1053,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 97,
+                  "line": 101,
                   "column": 8
                 },
                 "end": {
-                  "line": 101,
+                  "line": 105,
                   "column": 9
                 }
               },
@@ -1042,11 +1074,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 106,
+                  "line": 110,
                   "column": 8
                 },
                 "end": {
-                  "line": 109,
+                  "line": 113,
                   "column": 9
                 }
               },
@@ -1063,11 +1095,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 114,
+                  "line": 118,
                   "column": 8
                 },
                 "end": {
-                  "line": 117,
+                  "line": 121,
                   "column": 9
                 }
               },
@@ -1084,11 +1116,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 122,
+                  "line": 126,
                   "column": 8
                 },
                 "end": {
-                  "line": 125,
+                  "line": 129,
                   "column": 9
                 }
               },
@@ -1105,11 +1137,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 130,
+                  "line": 134,
                   "column": 8
                 },
                 "end": {
-                  "line": 133,
+                  "line": 137,
                   "column": 9
                 }
               },
@@ -1126,11 +1158,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 138,
+                  "line": 142,
                   "column": 8
                 },
                 "end": {
-                  "line": 140,
+                  "line": 144,
                   "column": 9
                 }
               },
@@ -1146,11 +1178,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 149,
+                  "line": 153,
                   "column": 6
                 },
                 "end": {
-                  "line": 152,
+                  "line": 156,
                   "column": 7
                 }
               },
@@ -1163,11 +1195,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 157,
+                  "line": 161,
                   "column": 6
                 },
                 "end": {
-                  "line": 181,
+                  "line": 176,
                   "column": 7
                 }
               },
@@ -1179,16 +1211,46 @@
               ]
             },
             {
+              "name": "_getFormattedValue",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 183,
+                  "column": 6
+                },
+                "end": {
+                  "line": 191,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "string"
+                },
+                {
+                  "name": "format",
+                  "type": "?string"
+                },
+                {
+                  "name": "currency",
+                  "type": "boolean"
+                }
+              ]
+            },
+            {
               "name": "_unformat",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 186,
+                  "line": 196,
                   "column": 6
                 },
                 "end": {
-                  "line": 190,
+                  "line": 200,
                   "column": 7
                 }
               },
@@ -1205,11 +1267,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 195,
+                  "line": 205,
                   "column": 6
                 },
                 "end": {
-                  "line": 200,
+                  "line": 210,
                   "column": 7
                 }
               },
@@ -1226,11 +1288,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 205,
+                  "line": 215,
                   "column": 6
                 },
                 "end": {
-                  "line": 208,
+                  "line": 218,
                   "column": 7
                 }
               },
@@ -1247,11 +1309,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 213,
+                  "line": 223,
                   "column": 6
                 },
                 "end": {
-                  "line": 216,
+                  "line": 226,
                   "column": 7
                 }
               },
@@ -1268,11 +1330,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 221,
+                  "line": 231,
                   "column": 6
                 },
                 "end": {
-                  "line": 226,
+                  "line": 236,
                   "column": 7
                 }
               },
@@ -1289,11 +1351,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 228,
+              "line": 238,
               "column": 41
             }
           },
@@ -1302,14 +1364,14 @@
           "attributes": [
             {
               "name": "format",
-              "description": "The format used to generate the output",
+              "description": "The format used to generate the output. Set to a [valid numbro.js\nformat string](http://numbrojs.com/format.html).\n\nSet to \"NONE\" to skip formatting and use the `value` to set the\n`formattedValue` directly.",
               "sourceRange": {
                 "start": {
-                  "line": 38,
+                  "line": 42,
                   "column": 6
                 },
                 "end": {
-                  "line": 40,
+                  "line": 44,
                   "column": 7
                 }
               },
@@ -1322,11 +1384,11 @@
               "description": "Specify whether the value should be formatted as a currency",
               "sourceRange": {
                 "start": {
-                  "line": 45,
+                  "line": 49,
                   "column": 6
                 },
                 "end": {
-                  "line": 48,
+                  "line": 52,
                   "column": 7
                 }
               },
@@ -1339,11 +1401,11 @@
               "description": "Provide localization for currency formatting",
               "sourceRange": {
                 "start": {
-                  "line": 53,
+                  "line": 57,
                   "column": 6
                 },
                 "end": {
-                  "line": 56,
+                  "line": 60,
                   "column": 7
                 }
               },
@@ -1356,11 +1418,11 @@
               "description": "Provide a new default format for `0` value",
               "sourceRange": {
                 "start": {
-                  "line": 61,
+                  "line": 65,
                   "column": 6
                 },
                 "end": {
-                  "line": 63,
+                  "line": 67,
                   "column": 7
                 }
               },
@@ -1373,11 +1435,11 @@
               "description": "The number value to be formatted",
               "sourceRange": {
                 "start": {
-                  "line": 81,
+                  "line": 85,
                   "column": 8
                 },
                 "end": {
-                  "line": 83,
+                  "line": 87,
                   "column": 9
                 }
               },
@@ -1389,11 +1451,11 @@
               "description": "The formatted string representation of the value. Only set if\n`targetElement` is not defined",
               "sourceRange": {
                 "start": {
-                  "line": 89,
+                  "line": 93,
                   "column": 8
                 },
                 "end": {
-                  "line": 92,
+                  "line": 96,
                   "column": 9
                 }
               },
@@ -1405,11 +1467,11 @@
               "description": "Reflect if the value is negative",
               "sourceRange": {
                 "start": {
-                  "line": 97,
+                  "line": 101,
                   "column": 8
                 },
                 "end": {
-                  "line": 101,
+                  "line": 105,
                   "column": 9
                 }
               },
@@ -1421,11 +1483,11 @@
               "description": "A formatted String to extract a value from",
               "sourceRange": {
                 "start": {
-                  "line": 106,
+                  "line": 110,
                   "column": 8
                 },
                 "end": {
-                  "line": 109,
+                  "line": 113,
                   "column": 9
                 }
               },
@@ -1437,11 +1499,11 @@
               "description": "The unformatted Number representation of the unformat value",
               "sourceRange": {
                 "start": {
-                  "line": 114,
+                  "line": 118,
                   "column": 8
                 },
                 "end": {
-                  "line": 117,
+                  "line": 121,
                   "column": 9
                 }
               },
@@ -1453,11 +1515,11 @@
               "description": "Provide a new default format",
               "sourceRange": {
                 "start": {
-                  "line": 122,
+                  "line": 126,
                   "column": 8
                 },
                 "end": {
-                  "line": 125,
+                  "line": 129,
                   "column": 9
                 }
               },
@@ -1469,11 +1531,11 @@
               "description": "Provide a new default format for currency",
               "sourceRange": {
                 "start": {
-                  "line": 130,
+                  "line": 134,
                   "column": 8
                 },
                 "end": {
-                  "line": 133,
+                  "line": 137,
                   "column": 9
                 }
               },
@@ -1485,11 +1547,11 @@
               "description": "Target element to assign the formatted value to. If defined\n`formattedValue` won't be assigned",
               "sourceRange": {
                 "start": {
-                  "line": 138,
+                  "line": 142,
                   "column": 8
                 },
                 "end": {
-                  "line": 140,
+                  "line": 144,
                   "column": 9
                 }
               },

--- a/px-number-formatter-behavior.html
+++ b/px-number-formatter-behavior.html
@@ -34,7 +34,11 @@ All modifications are Copyright 2017 by GE. Please see LICENSE.md.
     properties: {
 
       /**
-       * The format used to generate the output
+       * The format used to generate the output. Set to a [valid numbro.js
+       * format string](http://numbrojs.com/format.html).
+       *
+       * Set to "NONE" to skip formatting and use the `value` to set the
+       * `formattedValue` directly.
        */
       format: {
         type: String
@@ -160,18 +164,9 @@ All modifications are Copyright 2017 by GE. Please see LICENSE.md.
           return;
         }
 
-        var formatted;
         this._setNegative(value < 0);
-        if(this.currency) {
-          if(this.format) {
-            formatted = numbro(value).formatCurrency(this.format);
-          } else {
-            formatted = numbro(value).formatCurrency();
-          }
-        } else {
-          formatted = numbro(value).format(this.format);
-        }
 
+        var formatted = this._getFormattedValue(this.value, this.format, this.currency);
         formatted = formatted === 'NaN' ? '' : formatted;
 
         if(this.targetElement) {
@@ -179,6 +174,21 @@ All modifications are Copyright 2017 by GE. Please see LICENSE.md.
         } else {
           this.set('formattedValue', formatted);
         }
+      },
+
+      /**
+       * @param  {string} value
+       * @param  {?string} format
+       * @param  {boolean} currency
+       */
+      _getFormattedValue: function(value, format, currency) {
+        if (format === 'NONE') {
+          return value;
+        }
+        if (currency) {
+          return numbro(value).formatCurrency(format);
+        }
+        return numbro(value).format(format);
       },
 
       /**

--- a/px-number-formatter-no-display.html
+++ b/px-number-formatter-no-display.html
@@ -1,7 +1,5 @@
 <link rel="import" href="../polymer/polymer.html"/>
-
-<link rel="import" href="px-number-formatter-behavior.html">
-<link rel="import" href="css/px-number-formatter-styles.html">
+<link rel="import" href="px-number-formatter-behavior.html"/>
 
 <!--
 A wrapper for px-number-formatter-behavior to provide declarative number formatting without display.

--- a/px-number-formatter.html
+++ b/px-number-formatter.html
@@ -1,7 +1,5 @@
 <link rel="import" href="../polymer/polymer.html"/>
-
-<link rel="import" href="px-number-formatter-behavior.html">
-<link rel="import" href="css/px-number-formatter-styles.html">
+<link rel="import" href="px-number-formatter-behavior.html"/>
 
 <!--
 A wrapper for px-number-formatter-behavior to provide declarative number formatting and display.

--- a/test/px-number-formatter-custom-tests.js
+++ b/test/px-number-formatter-custom-tests.js
@@ -153,3 +153,32 @@ suite('px-number-formatter unformat', function() {
     assert.equal(formatter.unformattedValue, 5000);
   });
 });
+
+suite('px-number-formatter no format', function() {
+  let fx,
+      formatter,
+      formatterNoDisplay;
+
+  setup(function(done) {
+    fx = fixture('noFormatFixture');
+    flush(function() {
+      formatter = Polymer.dom(fx.root).querySelector('px-number-formatter');
+      formatter.value = 12398.49;
+      formatter.format = 'NONE';
+
+      formatterNoDisplay = Polymer.dom(fx.root).querySelector('px-number-formatter-no-display');
+      formatterNoDisplay.value = 12398.49;
+      formatterNoDisplay.format = 'NONE';
+
+      done();
+    });
+  });
+
+  test('Check value is not formatted if format="NONE"', function() {
+    assert.equal(formatter.targetElement.textContent, '12398.49');
+  });
+
+  test('Check value is not formatted if format="NONE" nodisplay', function() {
+    assert.equal(formatterNoDisplay.formattedValue, '12398.49');
+  });
+});

--- a/test/px-number-formatter-test-fixture.html
+++ b/test/px-number-formatter-test-fixture.html
@@ -28,5 +28,12 @@
     <h3>Web Component Test : Fixture for px-number-formatter</h3>
     <px-number-formatter id="formatter"></px-number-formatter>
     <px-number-formatter-no-display id="formatterNoDisplay"></px-number-formatter-no-display>
+
+    <test-fixture id="noFormatFixture">
+      <template>
+        <px-number-formatter></px-number-formatter>
+        <px-number-formatter-no-display></px-number-formatter-no-display>
+      </template>
+    </test-fixture>
   </body>
 </html>


### PR DESCRIPTION
* Remove import for CSS file with nothing in it
* Add the new "NONE" option for the format property. Setting format to
  "NONE" skips using numbro to format the value and sets it directly
  to the formattedValue.
* Add new tests to cover